### PR TITLE
Limit excalidraw Node.js to v22 in Renovate update config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) VERSION=\"(?<currentValue>.+?)\"\\s"
       ]
+    },
+    {
+      "datasource": "docker",
+      "packageName": "node",
+      "managerFilePatterns": [
+        "images/excalidraw/Dockerfile"
+      ],
+      "allowedVersions": ">=22.22.3 <23.0.0"
     }
   ]
 }


### PR DESCRIPTION
- Excalidraw has not released a version since Mar 2025, other than one security release
- It still pins Node.js v22
- Grouping together with Node.js updates in other images cause build error and manual intervention