### PR TITLE
Always set latest tag on default branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}},value=${{ steps.version.outputs.version }}
-            type=sha
+            type=sha,priority=300
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to GitHub Container Registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}},value=${{ steps.version.outputs.version }}
             type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Login to GitHub Container Registry
         if: steps.check.outputs.changed == 'true'


### PR DESCRIPTION
Latest tag is not set by default if not using semver versioning. Always set `latest` even when only `sha` is available