### PR TITLE
Fix pnpm build related to v11.20.0 release

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
         "/(^|/)Dockerfile\\.[^/]*$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) VERSION=\"(?<currentValue>.+?)\"\\s"
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))? packageName=(?<packageName>.+?)(?: versioning=(?<versioning>[a-z-]+?))?\\s(?:ENV|ARG) [A-Z0-9_]*VERSION=\"(?<currentValue>.+?)\"\\s"
       ]
     }
   ],

--- a/images/homebox/Dockerfile
+++ b/images/homebox/Dockerfile
@@ -20,13 +20,17 @@ FROM library/node:26.5.1-alpine3.24@sha256:233761595746769ebfdb6090f44fc7cdf818a
 
 WORKDIR /app
 
+# pinned: pnpm 11.20.0 can't delegate to the packageManager-declared pnpm 10.x
+# on musl, see https://github.com/pnpm/pnpm/issues/13622
+ENV PNPM_VERSION="11.19.0"
+
 COPY --from=clone /app/homebox ./homebox
 
 RUN apk update && \
   apk upgrade && \
   # somehow build fails without git
   apk add --no-cache git && \
-  npm install -g pnpm && \
+  npm install -g "pnpm@$PNPM_VERSION" && \
   cd homebox/frontend && \
   pnpm install --frozen-lockfile && \
   pnpm build

--- a/images/homebox/Dockerfile
+++ b/images/homebox/Dockerfile
@@ -20,8 +20,6 @@ FROM library/node:26.5.1-alpine3.24@sha256:233761595746769ebfdb6090f44fc7cdf818a
 
 WORKDIR /app
 
-# pinned: pnpm 11.20.0 can't delegate to the packageManager-declared pnpm 10.x
-# on musl, see https://github.com/pnpm/pnpm/issues/13622
 ENV PNPM_VERSION="11.19.0"
 
 COPY --from=clone /app/homebox ./homebox

--- a/images/homebox/Dockerfile
+++ b/images/homebox/Dockerfile
@@ -20,6 +20,7 @@ FROM library/node:26.5.1-alpine3.24@sha256:233761595746769ebfdb6090f44fc7cdf818a
 
 WORKDIR /app
 
+# renovate: datasource=npm depName=pnpm packageName=pnpm
 ENV PNPM_VERSION="11.19.0"
 
 COPY --from=clone /app/homebox ./homebox

--- a/images/inngest/Dockerfile
+++ b/images/inngest/Dockerfile
@@ -14,12 +14,14 @@ FROM library/node:26.5.1-alpine3.24@sha256:233761595746769ebfdb6090f44fc7cdf818a
 
 WORKDIR /app
 
+ENV PNPM_VERSION="11.19.0"
+
 COPY --from=clone /app/inngest ./inngest
 
 RUN apk add --no-cache make && \
   cd inngest && \
   npm install --global corepack@latest && \
-  corepack prepare pnpm --activate && \
+  corepack prepare "pnpm@$PNPM_VERSION" --activate && \
   make build-ui
 
 FROM --platform=$BUILDPLATFORM library/golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build-backend

--- a/images/inngest/Dockerfile
+++ b/images/inngest/Dockerfile
@@ -14,6 +14,7 @@ FROM library/node:26.5.1-alpine3.24@sha256:233761595746769ebfdb6090f44fc7cdf818a
 
 WORKDIR /app
 
+# renovate: datasource=npm depName=pnpm packageName=pnpm
 ENV PNPM_VERSION="11.19.0"
 
 COPY --from=clone /app/inngest ./inngest


### PR DESCRIPTION
- Pin pnpm version to v11.19.0
- pnpm 11.20.0 can't delegate to the packageManager-declared pnpm 10.x
  - `[ERROR] Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it is missing from pnpm-lock.yaml.`
  - https://github.com/pnpm/pnpm/issues/13622