### PR TITLE
Fix excalidraw Node.js version constraint never applying

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
     {
       "matchDatasources": "docker",
       "matchPackageNames": [
-        "node"
+        "/(^|/)node$/"
       ],
       "matchFileNames": [
         "images/excalidraw/Dockerfile"


### PR DESCRIPTION
`matchPackageNames` is matched against `packageName` only, which is `library/node` for a line like:

```dockerfile
FROM library/node:22.23.2-trixie@sha256:97337fb5b20347953eb4b9aa0183c73259a0e21934b07845f04278e4954ae61a AS build
```

Renovate strips the `library/` prefix from `depName`, not `packageName`, and the `depName` fallback was removed in v37. The exact string `"node"` never matched, so `allowedVersions` was silently ignored and excalidraw kept being pulled into the Node.js major update PRs.

Use the same regex Renovate's internal presets use for Node.js images.

Verified with a local dry run against `main`:

```console
$ renovate --platform=local --dry-run=lookup
```

excalidraw's `node` dep goes from a major update:

```json
"updates": [{ "bucket": "major", "newVersion": "24.19.0", "newValue": "24.19.0-trixie" }]
```

to no update at all:

```json
"updates": []
```
